### PR TITLE
fix: manejo de excepcion al obtener usuario sin ultima ubicacion

### DIFF
--- a/Backend/Aplication/Services/UserService.cs
+++ b/Backend/Aplication/Services/UserService.cs
@@ -113,12 +113,12 @@ public class UserService: IUserService
                     Name = user.ProfilePic.Name,
                     Link = user.ProfilePic.Link
                 },
-                LastLocation = new LastLocationUserDTO
+                LastLocation = user.LastLocation != null ? new LastLocationUserDTO
                 {
                     Description = user.LastLocation.Description,
                     Name = user.LastLocation.Name,
                     Id = user.LastLocation.Id
-                },
+                } : null,
                 Career = new CareerResponseDTO
                 {
                     Id = user.Career.Id,


### PR DESCRIPTION
Daba error cuando obtenía un usuario recien creado porque no tenía una última ubicación, solo agregué que esos casos devuelva null.